### PR TITLE
pghub-baseのバージョンアップに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,19 @@ Or install it yourself as:
     $ gem install pghub-lgtm
 
 ## Usage
+### Get github access token
 
+### Deploy to heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/playground-live/pghub-server/tree/lgtm)
+
+### Deploy manually
 - mount in routes.rb
 
 ```ruby
-mount Pghub::Base::Engine => 'some path'
+mount Pghub::Base::Engine => 'some/path'
 ```
 
-- Get github access token
 - Add following settings to config/initializers/pghub.rb
 
 ```ruby
@@ -39,7 +44,25 @@ end
 ```
 
 - Deploy to server
-- Set webhook to your repository
+
+
+### Set webhook to your repository
+
+|||
+|:-:|:-:|
+|URL|heroku'sURL/github\_webhooks or heroku'sURL/some/path|
+|Content-Type|application/json|
+|Secret||
+|event|check the following events|
+
+#### events
+- commit comment
+- issue comment
+- issues
+- pull request
+- pull request comment
+- pull request review comment
+
 
 ## Development
 

--- a/lib/pghub/lgtm/version.rb
+++ b/lib/pghub/lgtm/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module Lgtm
-    VERSION = "1.1"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/pghub/lgtm/version.rb
+++ b/lib/pghub/lgtm/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module Lgtm
-    VERSION = "1.0.0"
+    VERSION = "1.1"
   end
 end

--- a/pghub-lgtm.gemspec
+++ b/pghub-lgtm.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "pghub-base", "~> 1.0.0"
+  spec.add_dependency "pghub-base", ">= 1.0.0"
   spec.add_dependency "mechanize"
 end


### PR DESCRIPTION
# WHAT
- gemspecにおけるバージョン表記を`~> 1.0.0`から`>= 1.0.0`に変更
- READMEにUsageの詳細、Deploy to herokuボタン配置

# WHY
- pghub-baseを`2.0`にupdateするため
